### PR TITLE
Improve installation example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ script to install arch linux very quickly. By default it will install a setup wi
 - Get the scripts from this repo
 - Launch ./install.sh from the script folder and answer the questions.
 
-  **example:**  
-  curl -L https://github.com/slayerizer/arch_installer/archive/master.zip --  output scripts.zip    
-  pacman -Sy --noconfirm unzip    
-  unzip scripts.zip  
-  cd arch_installer-master  
-  chmod +x *.sh  
-  ./install.sh  
+  **Example:**
+  
+      curl -L https://github.com/slayerizer/arch_installer/archive/master.zip --output scripts.zip
+      bsdtar zxf scripts.zip
+      cd arch_installer-master
+      chmod +x *.sh
+      ./install.sh
 
 
 ## Current Requirements


### PR DESCRIPTION
This PR addresses a few things in the example commands to use this script:

- Use `bsdtar` (which is part of the base system) to avoid needing to install `unzip`.
- Remove spaces after `output` in `curl` command so that it properly recognises this flag.
- Indent example so that it is formatted as code when the Markdown is rendered.